### PR TITLE
Add Documenter.jl

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,22 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia --project=docs/ docs/make.jl

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-
-Manifest.toml
+**/Manifest.toml
 .vscode/settings.json
+
+/build
+/docs/build/

--- a/Project.toml
+++ b/Project.toml
@@ -21,8 +21,9 @@ julia = "1"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "DataFrames"]
+test = ["Test", "DataFrames", "Documenter"]

--- a/README.md
+++ b/README.md
@@ -1,78 +1,17 @@
 # SimpleANOVA.jl
 
-[![Build Status](https://travis-ci.org/BioTurboNick/SimpleANOVA.jl.svg?branch=master)](https://travis-ci.org/BioTurboNick/SimpleANOVA.jl)
-[![codecov.io](https://codecov.io/github/BioTurboNick/SimpleANOVA.jl/coverage.svg?branch=master)](https://codecov.io/github/BioTurboNick/SimpleANOVA.jl?branch=master)
-
 Analysis of Variance for Julia, the old-fashioned way.
 
-This is a basic attempt to get a simple ANOVA implementation for Julia that works with data directly - no linear models.
+| Documentation | CI Status
+|:-----------------:|:------------------:|
+| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][ci-img]][ci-url] |
 
-The goal is to allow one function to do as much for you as possible, automatically choosing the right calculations.
+[docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
+[docs-latest-url]: https://BioTurboNick.github.io/SimpleANOVA.jl/dev
 
-Handles ANOVA with up to 3 crossed factors (fixed or random) and arbitrarily many nested factors. Requires equal replication. (If you have missing values, there are techniques to fill them in, within limits; e.g. use the average of the cell for one value).
-It uses multidimensional arrays to interpret the structure of the data. Replicates should either be indexed along the first dimension or contained in a vector, with Factor B and Factor A the next available indices.
+[docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
+[docs-stable-url]: https://BioTurboNick.github.io/SimpleANOVA.jl/stable
 
-Can also work with multiple vectors and DataFrames.
+[ci-img]: https://github.com/BioTurboNick/SimpleANOVA.jl/workflows/CI-stable/badge.svg
+[ci-url]: https://github.com/BioTurboNick/SimpleANOVA.jl/actions?query=workflow%3ACI-stable+branch%3Amaster
 
-**New in v0.5**: ω² effect size (Disclaimer: effect size calculations for nested and 3-way mixed ANOVA is inferred and may not be correct.)
-
-**New in v0.6**: Linear contrasts added for planned post-hoc tests between factor levels. (Disclaimer: Uncertain if contrasts for multiple factors are correct.)
-
-**New in v0.7**: Repeated measures added. Effect size not yet supported.
-
-**New in v0.8**: Implemented generalized ω² effect size which is robust to experimental design choice.
-
-See docstrings for usage.
-
-**Experimental, use at own risk!**
-
-Examples
---------
-```
-data                           # N-dimensional matrix of observations
-levene(data)                   # test data for homogeniety of variance
-result = anova(data)           # conduct the test
-plot(result)                   # create pairwise factor plots
-differencecontrasts(result, 2) # perform orthogonal series of difference contrasts for the levels of factor 2
-```
-```
-data                           # vector of observations
-factors                        # vector of factor level assignment vectors
-levene(data)                   # test data for homogeniety of variance
-result = anova(data, factors)  # conduct the test
-plot(result)                   # create pairwise factor plots
-contrast(result, [1, 2, 2, 2]) # calculate the contrast between factor level 1 of factor 1 with remaining factor levels
-```
-```
-df                                         # DataFrame
-factors                                    # vector of symbols for factor assignment columns
-levene(df, :observations, factors)         # test data for homogeniety of variance
-result = anova(df, :observations, factors) # conduct the test
-plot(result)                               # create pairwise factor plots
-simplecontrasts(result)                    # calculate the contrast between the first factor level (control) to each other level
-```
-
-Differences from SPSS
----------------------
-Choice of error terms for the F tests in mixed ANOVA follows Zar 1999, _Biostatistical Analysis_, and Howell 2013, _Statistical Methods for Psychology_, which differs from SPSS 25 Univariate GLM as follows:
-
-2-way ANOVA with 1 fixed and 1 random factor
-
-|                | A (Fixed) | B (Random) |
-|----------------|-----------|------------|
-| SPSS           | Error     | Error      |
-| SimpleANOVA.jl | A×B       | Error      |
-
-3-way ANOVA with 2 fixed and 1 random factors
-
-|                | A (Fixed) | B (Fixed) | C (Random)        | A×B   | A×C   | B×C   | A×B×C |
-|----------------|-----------|-----------|-------------------|-------|-------|-------|-------|
-| SPSS           | A×C       | B×C       | A×C + B×C - A×B×C | A×B×C | A×B×C | A×B×C | Error |
-| SimpleANOVA.jl | A×C       | B×C       | Error             | A×B×C | Error | Error | Error |
-
-3-way ANOVA with 1 fixed and 2 random factors
-
-|                | A (Fixed)         | B (Random)        | C (Random)        | A×B   | A×C   | B×C   | A×B×C |
-|----------------|-------------------|-------------------|-------------------|-------|-------|-------|-------|
-| SPSS           | A×C + A×B - A×B×C | A×B + B×C - A×B×C | A×C + B×C - A×B×C | A×B×C | A×B×C | A×B×C | Error |
-| SimpleANOVA.jl | A×C + A×B - A×B×C | B×C               | B×C               | A×B×C | A×B×C | Error | Error |

--- a/README.md
+++ b/README.md
@@ -15,3 +15,23 @@ Analysis of Variance for Julia, the old-fashioned way.
 [ci-img]: https://github.com/BioTurboNick/SimpleANOVA.jl/workflows/CI-stable/badge.svg
 [ci-url]: https://github.com/BioTurboNick/SimpleANOVA.jl/actions?query=workflow%3ACI-stable+branch%3Amaster
 
+This is a basic attempt to get a simple ANOVA implementation for Julia that works with data directly - no linear models.
+
+The goal is to allow one function to do as much for you as possible, automatically choosing the right calculations.
+
+Handles ANOVA with up to 3 crossed factors (fixed or random) and arbitrarily many nested factors. Requires equal replication. (If you have missing values, there are techniques to fill them in, within limits; e.g. use the average of the cell for one value).
+It uses multidimensional arrays to interpret the structure of the data. Replicates should either be indexed along the first dimension or contained in a vector, with Factor B and Factor A the next available indices.
+
+Can also work with multiple vectors and DataFrames.
+
+**New in v0.5**: ω² effect size (Disclaimer: effect size calculations for nested and 3-way mixed ANOVA is inferred and may not be correct.)
+
+**New in v0.6**: Linear contrasts added for planned post-hoc tests between factor levels. (Disclaimer: Uncertain if contrasts for multiple factors are correct.)
+
+**New in v0.7**: Repeated measures added. Effect size not yet supported.
+
+**New in v0.8**: Implemented generalized ω² effect size which is robust to experimental design choice.
+
+See docstrings for usage.
+
+**Experimental, use at own risk!**

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,6 @@
 [deps]
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SimpleANOVA = "fff527a3-8410-504e-9ca3-60d5e79bb1e4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,24 @@
+using Documenter
+using SimpleANOVA
+
+# This ensures that the jldoctests are executed when running the tests.
+DocMeta.setdocmeta!(
+    SimpleANOVA,
+    :DocTestSetup,
+    :(using SimpleANOVA);
+    recursive=true
+)
+
+makedocs(
+    sitename = "SimpleANOVA.jl",
+    pages = [
+        "SimpleANOVA" => "index.md",
+        "API" => "api.md"
+    ],
+    format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
+    modules = [MCMCChains],
+    strict = true,
+    checkdocs = :exports
+)
+
+deploydocs(repo="github.com/BioTurboNick/SimpleANOVA.jl")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,7 +16,7 @@ makedocs(
         "API" => "api.md"
     ],
     format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
-    modules = [MCMCChains],
+    modules = [SimpleANOVA],
     strict = true,
     checkdocs = :exports
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,6 @@
 using Documenter
 using SimpleANOVA
 
-# This ensures that the jldoctests are executed when running the tests.
 DocMeta.setdocmeta!(
     SimpleANOVA,
     :DocTestSetup,

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,6 @@
+# API
+
+```@autodocs
+Modules = [SimpleANOVA]
+Order = [:function, :type]
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,92 @@
+# SimpleANOVA
+
+Analysis of Variance for Julia, the old-fashioned way.
+
+This is a basic attempt to get a simple ANOVA implementation for Julia that works with data directly - no linear models.
+
+The goal is to allow one function to do as much for you as possible, automatically choosing the right calculations.
+
+Handles ANOVA with up to 3 crossed factors (fixed or random) and arbitrarily many nested factors. Requires equal replication. (If you have missing values, there are techniques to fill them in, within limits; e.g. use the average of the cell for one value).
+It uses multidimensional arrays to interpret the structure of the data. Replicates should either be indexed along the first dimension or contained in a vector, with Factor B and Factor A the next available indices.
+
+Can also work with multiple vectors and DataFrames.
+
+Basic example
+--------
+```@example index
+using Random # hide
+Random.seed!(1) # hide
+using CategoricalArrays
+using DataFrames
+using SimpleANOVA
+
+df = DataFrame(
+  id = categorical(repeat(1:2; inner=6)),
+  a = categorical(repeat(1:3, inner=2, outer=2)),
+  b = categorical(repeat(1:2, 6)),
+  value = round.(rand(Float64, 12), digits=1)
+)
+
+anova(df, :value, [:b, :id, :a], [fixed, subject])
+```
+
+Other examples
+--------
+```
+data                           # N-dimensional matrix of observations
+levene(data)                   # test data for homogeniety of variance
+result = anova(data)           # conduct the test
+plot(result)                   # create pairwise factor plots
+differencecontrasts(result, 2) # perform orthogonal series of difference contrasts for the levels of factor 2
+```
+```
+data                           # vector of observations
+factors                        # vector of factor level assignment vectors
+levene(data)                   # test data for homogeniety of variance
+result = anova(data, factors)  # conduct the test
+plot(result)                   # create pairwise factor plots
+contrast(result, [1, 2, 2, 2]) # calculate the contrast between factor level 1 of factor 1 with remaining factor levels
+```
+```
+df                                         # DataFrame
+factors                                    # vector of symbols for factor assignment columns
+levene(df, :observations, factors)         # test data for homogeniety of variance
+result = anova(df, :observations, factors) # conduct the test
+plot(result)                               # create pairwise factor plots
+simplecontrasts(result)                    # calculate the contrast between the first factor level (control) to each other level
+```
+
+Differences from SPSS
+---------------------
+Choice of error terms for the F tests in mixed ANOVA follows Zar 1999, _Biostatistical Analysis_, and Howell 2013, _Statistical Methods for Psychology_, which differs from SPSS 25 Univariate GLM as follows:
+
+2-way ANOVA with 1 fixed and 1 random factor
+
+|                | A (Fixed) | B (Random) |
+|----------------|-----------|------------|
+| SPSS           | Error     | Error      |
+| SimpleANOVA.jl | A×B       | Error      |
+
+3-way ANOVA with 2 fixed and 1 random factors
+
+|                | A (Fixed) | B (Fixed) | C (Random)        | A×B   | A×C   | B×C   | A×B×C |
+|----------------|-----------|-----------|-------------------|-------|-------|-------|-------|
+| SPSS           | A×C       | B×C       | A×C + B×C - A×B×C | A×B×C | A×B×C | A×B×C | Error |
+| SimpleANOVA.jl | A×C       | B×C       | Error             | A×B×C | Error | Error | Error |
+
+3-way ANOVA with 1 fixed and 2 random factors
+
+|                | A (Fixed)         | B (Random)        | C (Random)        | A×B   | A×C   | B×C   | A×B×C |
+|----------------|-------------------|-------------------|-------------------|-------|-------|-------|-------|
+| SPSS           | A×C + A×B - A×B×C | A×B + B×C - A×B×C | A×C + B×C - A×B×C | A×B×C | A×B×C | A×B×C | Error |
+| SimpleANOVA.jl | A×C + A×B - A×B×C | B×C               | B×C               | A×B×C | A×B×C | Error | Error |
+
+Changelog
+--------
+**New in v0.5**: ω² effect size (Disclaimer: effect size calculations for nested and 3-way mixed ANOVA is inferred and may not be correct.)
+
+**New in v0.6**: Linear contrasts added for planned post-hoc tests between factor levels. (Disclaimer: Uncertain if contrasts for multiple factors are correct.)
+
+**New in v0.7**: Repeated measures added. Effect size not yet supported.
+
+**New in v0.8**: Implemented generalized ω² effect size which is robust to experimental design choice.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,22 @@
+using CategoricalArrays
+using DataFrames
+using Documenter
 using SimpleANOVA
 using Test
-using DataFrames
-using CategoricalArrays
 
 @testset "SimpleANOVA Tests" begin
-include("test_anova.jl")
-include("test_pretests.jl")
-include("test_contrasts.jl")
-include("test_show.jl")
+    DocMeta.setdocmeta!(
+        SimpleANOVA,
+        :DocTestSetup,
+        :(using SimpleANOVA);
+        recursive=true
+    )
+
+    # Ensures that jldoctests also pass.
+    doctest(SimpleANOVA)
+
+    include("test_anova.jl")
+    include("test_pretests.jl")
+    include("test_contrasts.jl")
+    include("test_show.jl")
 end


### PR DESCRIPTION
This pull requests adds documentation via Documenter.jl. I've tried to keep it as simple as possible and stick to the conventions regarding documentation in Julia. For example, there is a index page which is more readable and an API page which lists all the docstrings. To be future proof, I've already ensured that jldoctests run when tests are executed. jldoctests are a nice way to keep code and tests close and are used by many packages and Julia base.

I've tested this PR in a CI job on my fork. There it passes. However, before the documentation will be deployed, you need to add a private key to your repository. You can find instructions at <https://juliaregistries.github.io/CompatHelper.jl/dev/#Installation,-step-2:-Set-up-the-SSH-deploy-key>; name the key  `DOCUMENTER_KEY ` instead of  `COMPATHELPER_PRIV `. (There is also an instruction for setting up the SSH key at Documenter but that one is less convenient, I think.) 