### PR TITLE
Reduce potential for numerical instability

### DIFF
--- a/src/anova.jl
+++ b/src/anova.jl
@@ -194,7 +194,11 @@ function anovakernel(observations::AbstractArray{<:Number}, factornames, factort
     cellsdf = length(cellmeans) - 1
     cellsvar = anovavalue(cellsname, var(cellmeans) * nreplicates, cellsdf)
 
-    errorvar = AnovaFactor(errorname, totalvar - cellsvar)
+    if totalvar ≈ cellsvar
+        errorvar = AnovaFactor(errorname, 0)
+    else
+        errorvar = AnovaFactor(errorname, totalvar - cellsvar)
+    end
 
     nnested = count(isnested, factortypes)
     nestedfactornames = @view factornames[1:nnested]
@@ -278,7 +282,15 @@ function anovafactors(cellmeans, nreplicates, factornames)
         iupperfactorvars = [allfactorvars[findall(x -> x ⊆ i, allfactors)] for i ∈ ifactors]
 
         ifactornames = [makefactorname(factornames[i]) for i ∈ ifactors]
-        ifactorss = [var(mean(cellmeans, dims = iotherfactors[i]), corrected = false) * N - sum(iupperfactorvars[i]).ss for i ∈ eachindex(iotherfactors)]
+        ifactorss = map(eachindex(iotherfactors)) do i
+            x = var(mean(cellmeans, dims = iotherfactors[i]), corrected = false) * N
+            y = sum(sort!([iufv.ss for iufv ∈ iupperfactorvars[i]]))
+            if x ≈ y
+                0
+            else
+                x - y
+            end
+        end
         ifactordf = isempty(iupperfactorvars[1]) ? [size(cellmeans, invertfactorindex(i, nfactors)) - 1 for i ∈ factors] :
                                                    [prod(f.df for f ∈ iupperfactorvars[j][1:i]) for j ∈ eachindex(iotherfactors)]
         ifactorvars = AnovaFactor.(ifactornames, ifactorss, ifactordf)
@@ -443,7 +455,9 @@ function nestedfactors(cellmeans, nreplicates, factornames, errorvar)
     nestedvars = AnovaFactor[]
     for i ∈ 1:nnested
         nestedmeans = mean(cellmeans, dims = 1)
-        ss = sum((cellmeans .- nestedmeans) .^ 2) * nreplicates
+        diffs = cellmeans .- nestedmeans
+        diffs[abs.(diffs) .< √eps()] .= 0
+        ss = sum(sort!(diffs .^ 2 |> vec)) * nreplicates
         df = (size(cellmeans, 1) - 1) * prod(size(nestedmeans))
         push!(nestedvars, AnovaFactor(factornames[i], ss, df))
         nreplicates *= size(cellmeans, 1)
@@ -518,7 +532,11 @@ end
 
 function threeway_random_error(interaction_ab, interaction_bc, interaction_abc)
     reducedmeansquare(factor::AnovaFactor) = factor.ms ^ 2 / factor.df
-    ms = interaction_ab.ms + interaction_bc.ms - interaction_abc.ms
+    if interaction_ab.ms + interaction_bc.ms ≈ interaction_abc.ms
+        ms = 0
+    else
+        ms = interaction_ab.ms + interaction_bc.ms - interaction_abc.ms
+    end
     df = ms ^ 2 / (reducedmeansquare(interaction_ab) + reducedmeansquare(interaction_bc) + reducedmeansquare(interaction_abc))
     AnovaFactor("", ms * df, df, ms)
 end
@@ -541,11 +559,11 @@ function effectsizeω²(factorvars, factorerrorvars, nestedvars, nestederrorvars
     
     containsrandomfactor = random .∈ combinations(factortypes)
     length(containsrandomfactor) == length(factorvars) || pop!(containsrandomfactor)
-    σ²random = sum(σ²factorvars[containsrandomfactor])
+    σ²random = sum(sort(σ²factorvars[containsrandomfactor]))
 
     subjecterrorvars = (errorvar, subjectvars...)
-    σ²nested = !isempty(nestedvars) ? sum(σ²nestedvars) : 0
-    σ²error = N * sum(s.ss for s ∈ subjecterrorvars) / sum(s.df for s ∈ subjecterrorvars) # pool error from subject factors
+    σ²nested = !isempty(nestedvars) ? sum(sort(σ²nestedvars)) : 0
+    σ²error = N * sum(sort!([s.ss for s ∈ subjecterrorvars])) / sum(sort!([s.df for s ∈ subjecterrorvars])) # pool error from subject factors
     
     σ²id = σ²random + σ²nested + σ²error # sum of all random-effects variance
     ω² = σ²factorvars ./ (.!containsrandomfactor .* σ²factorvars .+ σ²id) # factor only needs to appear in denominator if a fixed-effect
@@ -554,4 +572,12 @@ function effectsizeω²(factorvars, factorerrorvars, nestedvars, nestederrorvars
     return [ω²; ω²nested]
 end
 
-σ²component(factorvars, factorerrorvars) = [factorvars[i].ss - factorvars[i].df * factorerrorvars[i].ms for i ∈ eachindex(factorvars)]
+function σ²component(factorvars, factorerrorvars)
+    map(eachindex(factorvars)) do i
+        if factorvars[i].ss ≈ factorvars[i].df * factorerrorvars[i].ms
+            0
+        else
+            factorvars[i].ss - factorvars[i].df * factorerrorvars[i].ms
+        end
+    end 
+end


### PR DESCRIPTION
This PR does two things to limit numerical instability:
* Where floating point values are subtracted, first tests if they are approximately equal (|x|< sqrt(eps())) and if so, replaces the result with a 0
* Where floating point values are summed, sorts them to proceed from smallest to largest

Hopefully resolves #22 